### PR TITLE
Direct Linear Solvers for Symmetric Positive Definite Toeplitz Matrices

### DIFF
--- a/src/ToeplitzMatrices.jl
+++ b/src/ToeplitzMatrices.jl
@@ -7,7 +7,7 @@ import Base: convert, *, \, getindex, print_matrix, size, Matrix, +, -, copy, si
 import LinearAlgebra: cholesky, cholesky!, eigvals, inv, ldiv!, mul!, pinv, tril, triu
 
 using LinearAlgebra: LinearAlgebra, Adjoint, Factorization, factorize, Cholesky,
-    DimensionMismatch, dot, rmul!, sym_uplo
+    DimensionMismatch, dot, rmul!, sym_uplo, Symmetric
 
 using AbstractFFTs
 using AbstractFFTs: Plan

--- a/src/ToeplitzMatrices.jl
+++ b/src/ToeplitzMatrices.jl
@@ -7,7 +7,7 @@ import Base: convert, *, \, getindex, print_matrix, size, Matrix, +, -, copy, si
 import LinearAlgebra: cholesky, cholesky!, eigvals, inv, ldiv!, mul!, pinv, tril, triu
 
 using LinearAlgebra: LinearAlgebra, Adjoint, Factorization, factorize, Cholesky,
-    DimensionMismatch, rmul!, sym_uplo
+    DimensionMismatch, dot, rmul!, sym_uplo
 
 using AbstractFFTs
 using AbstractFFTs: Plan

--- a/src/directLinearSolvers.jl
+++ b/src/directLinearSolvers.jl
@@ -16,7 +16,7 @@ function durbin!(y::AbstractVector, r::AbstractVector)
     n = length(r)
     length(y) == n || throw(DimensionMismatch("length(y) = $(length(y)) ≠ $n = length(r)"))
     y[1] = -r[1]
-    α, β = -r[1], 1
+    α, β = -r[1], one(eltype(r))
     for k in 1:n-1
         β *= (1-α^2)
         r_k, y_k = @views r[1:k], y[1:k]
@@ -50,11 +50,11 @@ of T and returns a `Symmetric` wrapper of `B`.
 function trench!(B::AbstractMatrix, T::SymmetricToeplitz)
     r_0 = T.vc[1]
     r = @view T.vc[2:end]
-    if r_0 != 1 # levinson implementation assumes normalization of diagonal
+    if !isone(r_0) # levinson implementation assumes normalization of diagonal
         r /= r_0 # not in place so that we don't mutate T
     end
     S = trench!(B, r)
-    if r_0 != 1
+    if !isone(r_0)
         @. B /= r_0
     end
     return S
@@ -107,7 +107,7 @@ function levinson!(x::AbstractVector, r::AbstractVector, b::AbstractVector,
     length(b) == n || throw(DimensionMismatch("length(b) = $(length(b)) ≠ $n = length(r) + 1"))
     y[1] = -r[1]
     x[1] = b[1]
-    α, β = -r[1], 1
+    α, β = -r[1], one(eltype(r))
     @inbounds for k in 1:n-1
         β *= (1-α^2)
         r_k, x_k, y_k  = @views r[1:k], x[1:k], y[1:k]
@@ -126,11 +126,11 @@ end
 function levinson(T::SymmetricToeplitz, b::AbstractVector)
     r_0 = T.vc[1]
     r = @view T.vc[2:end]
-    if r_0 != 1 # levinson implementation assumes normalization of diagonal
+    if !isone(r_0) # levinson implementation assumes normalization of diagonal
         r /= r_0
     end
     x = levinson(r, b)
-    if r_0 != 1
+    if !isone(r_0)
         @. x /= r_0
     end
     return x

--- a/src/directLinearSolvers.jl
+++ b/src/directLinearSolvers.jl
@@ -1,0 +1,171 @@
+# implementation of direct linear solves and inversion (for symmetric p.d. matrices at this point)
+"""
+durbin(r::AbstractVector)
+computes `y = T \\ (-r)` where T = SymmetricToeplitz(vcat(1, r[1:end-1])).
+`T` is assumed to be positive definite. `r` is of length n.
+"""
+durbin(r::AbstractVector) = durbin!(zero(r), r)
+
+"""
+```
+    durbin!(y::AbstractVector, r::AbstractVector)
+```
+Same as `durbin` but uses pre-allocated vector `y` to store the result.
+"""
+function durbin!(y::AbstractVector, r::AbstractVector)
+    n = length(r)
+    length(y) == n || throw(DimensionMismatch("length(y) = $(length(y)) ≠ $n = length(r)"))
+    y[1] = -r[1]
+    α, β = -r[1], 1
+    for k in 1:n-1
+        β *= (1-α^2)
+        r_k, y_k = @views r[1:k], y[1:k]
+        α = -(r[k+1] + reverse_dot(r_k, y_k)) / β
+        reverse_increment!(y_k, y_k, α)
+        y[k+1] = α
+    end
+    return y
+end
+
+"""
+```
+    trench(T::SymmetricToeplitz)
+```
+Trench's algorithm (see page 213 of Golub & van Loan) computes inverse of a
+symmetric positive definite Toeplitz matrix in `O(n^2)` operations.
+"""
+function trench(T::SymmetricToeplitz)
+    n = checksquare(T)
+    B = zeros(eltype(T), n, n)
+    trench!(B, T)
+end
+
+"""
+```
+    trench!(B::AbstractMatrix, T::SymmetricToeplitz)
+```
+Same as `trench` but uses `B` to store the upper triangular portion of the inverse
+of T and returns a `Symmetric` wrapper of `B`.
+"""
+function trench!(B::AbstractMatrix, T::SymmetricToeplitz)
+    r_0 = T.vc[1]
+    r = @view T.vc[2:end]
+    if r_0 != 1 # levinson implementation assumes normalization of diagonal
+        r /= r_0 # not in place so that we don't mutate T
+    end
+    S = trench!(B, r)
+    if r_0 != 1
+        @. B /= r_0
+    end
+    return S
+end
+
+# computes inverse of K = SymmetricToeplitz(vcat(1, r))
+function trench(r::AbstractVector)
+    n = length(r) + 1
+    B = zeros(eltype(r), n, n)
+    trench!(B, r)
+end
+
+# computes inverse of K = SymmetricToeplitz(vcat(1, r))
+# uses B to store the inverse
+# NOTE: only populates entries on upper triangle since the inverse is symmetric
+function trench!(B::AbstractMatrix, r::AbstractVector)
+    n = checksquare(B)
+    n == length(r) + 1 || throw(DimensionMismatch())
+    y = durbin(r)
+    γ = inv(1 + dot(r, y))
+    ν = γ * y[end:-1:1]
+    B[1, 1] = γ
+    @. B[1, 2:n] = γ * y
+    for j in 2:n
+        for i in 2:j
+            @inbounds B[i, j] = B[i-1, j-1] + (ν[n+1-j] * ν[n+1-i] - ν[i-1] * ν[j-1]) / γ
+        end
+    end
+    return Symmetric(B)
+end
+
+"""
+```
+    levinson(r::AbstractVector, b::AbstractVector)
+```
+solves `x = T \\ b where T = SymmetricToeplitz(vcat(1, r)), i.e. T_{ij} = r[abs(i-j)]`` where by assumption `r[0] = 1` and `T` is positive definite.
+"""
+levinson(r::AbstractVector, b::AbstractVector) = levinson!(zero(b), r, b)
+
+"""
+```
+    levinson!(x::AbstractVector, r::AbstractVector, b::AbstractVector, y::AbstractVector = zero(x))
+```
+same as `levinson`, but uses the pre-allocated vector `x` to store the result.
+"""
+function levinson!(x::AbstractVector, r::AbstractVector, b::AbstractVector,
+                   y::AbstractVector = zero(x))
+    n = length(r) + 1
+    length(x) == n || throw(DimensionMismatch("length(x) = $(length(x)) ≠ $n = length(r) + 1"))
+    length(b) == n || throw(DimensionMismatch("length(b) = $(length(b)) ≠ $n = length(r) + 1"))
+    y[1] = -r[1]
+    x[1] = b[1]
+    α, β = -r[1], 1
+    @inbounds for k in 1:n-1
+        β *= (1-α^2)
+        r_k, x_k, y_k  = @views r[1:k], x[1:k], y[1:k]
+        μ = (b[k+1] - reverse_dot(r_k, x_k)) / β
+        reverse_increment!(x_k, y_k, μ)
+        x[k+1] = μ
+        if k < n-1
+            α = -(r[k+1] + reverse_dot(r_k, y_k)) / β
+            reverse_increment!(y_k, y_k, α) # computes y_k += α * reverse(y_k)
+            y[k+1] = α
+        end
+    end
+    return x
+end
+
+function levinson(T::SymmetricToeplitz, b::AbstractVector)
+    r_0 = T.vc[1]
+    r = @view T.vc[2:end]
+    if r_0 != 1 # levinson implementation assumes normalization of diagonal
+        r /= r_0
+    end
+    x = levinson(r, b)
+    if r_0 != 1
+        @. x /= r_0
+    end
+    return x
+end
+
+# computes dot(x, reverse(y)) efficiently
+function reverse_dot(x::AbstractArray, y::AbstractArray)
+    n = length(x)
+    n == length(y) || throw(DimensionMismatch())
+    d = zero(promote_type(eltype(x), eltype(y)))
+    @inbounds @simd for i in 1:n
+        d += x[i] * y[n-i+1]
+    end
+    return d
+end
+# computes x += α * reverse(y) efficiently without temporary
+# NOTE: works without allocations even when x === y
+function reverse_increment!(x::AbstractArray, y::AbstractArray = x, α::Number = 1)
+    n = length(x)
+    n == length(y) || throw(DimensionMismatch())
+    if x === y
+        @inbounds @simd for i in 1:n÷2
+            y_i = y[i] # important to store these for the iteration so that they aren't mutated
+            z_i = y[n-i+1]
+            x[i] += α * z_i
+            x[n-i+1] += α * y_i
+        end
+        if isodd(n)
+            i = (n÷2) + 1 # midpoint
+            x[i] += α * y[i]
+        end
+    else
+        @inbounds @simd for i in 1:n
+            x[i] += α * y[n-i+1]
+        end
+    end
+    return x
+end

--- a/src/directLinearSolvers.jl
+++ b/src/directLinearSolvers.jl
@@ -8,7 +8,6 @@ Computes `y = T \\ (-r)` where `T = SymmetricToeplitz(vcat(1, r[1:end-1]))`.
 durbin(r::AbstractVector) = durbin!(zero(r), r)
 
 """
-
     durbin!(y::AbstractVector, r::AbstractVector)
 
 Same as `durbin` but uses pre-allocated vector `y` to store the result.
@@ -29,7 +28,6 @@ function durbin!(y::AbstractVector, r::AbstractVector)
 end
 
 """
-
     trench(T::SymmetricToeplitz)
 
 Trench's algorithm (see page 213 of Golub & van Loan) computes inverse of a
@@ -42,11 +40,10 @@ function trench(T::SymmetricToeplitz)
 end
 
 """
-```
     trench!(B::AbstractMatrix, T::SymmetricToeplitz)
-```
+
 Same as `trench` but uses `B` to store the upper triangular portion of the inverse
-of T and returns a `Symmetric` wrapper of `B`.
+of `T` and returns a `Symmetric` wrapper of `B`.
 """
 function trench!(B::AbstractMatrix, T::SymmetricToeplitz)
     r_0 = T.vc[1]
@@ -88,16 +85,14 @@ function trench!(B::AbstractMatrix, r::AbstractVector)
 end
 
 """
-
     levinson(r::AbstractVector, b::AbstractVector)
 
-solves `x = T \\ b` where `T = SymmetricToeplitz(vcat(1, r))`, i.e. `T_{ij} = r[abs(i-j)]`
+Solves `x = T \\ b` where `T = SymmetricToeplitz(vcat(1, r))`, i.e. `T_{ij} = r[abs(i-j)]`
 where by assumption `r[0] = 1` and `T` is positive definite.
 """
 levinson(r::AbstractVector, b::AbstractVector) = levinson!(zero(b), r, b)
 
 """
-
     levinson!(x::AbstractVector, r::AbstractVector, b::AbstractVector, y::AbstractVector = zero(x))
 
 Same as `levinson`, but uses the pre-allocated vector `x` to store the result.

--- a/src/directLinearSolvers.jl
+++ b/src/directLinearSolvers.jl
@@ -1,15 +1,16 @@
 # implementation of direct linear solves and inversion (for symmetric p.d. matrices at this point)
 """
-durbin(r::AbstractVector)
-computes `y = T \\ (-r)` where T = SymmetricToeplitz(vcat(1, r[1:end-1])).
+    durbin(r::AbstractVector)
+
+Computes `y = T \\ (-r)` where `T = SymmetricToeplitz(vcat(1, r[1:end-1]))`.
 `T` is assumed to be positive definite. `r` is of length n.
 """
 durbin(r::AbstractVector) = durbin!(zero(r), r)
 
 """
-```
+
     durbin!(y::AbstractVector, r::AbstractVector)
-```
+
 Same as `durbin` but uses pre-allocated vector `y` to store the result.
 """
 function durbin!(y::AbstractVector, r::AbstractVector)
@@ -28,14 +29,14 @@ function durbin!(y::AbstractVector, r::AbstractVector)
 end
 
 """
-```
+
     trench(T::SymmetricToeplitz)
-```
+
 Trench's algorithm (see page 213 of Golub & van Loan) computes inverse of a
 symmetric positive definite Toeplitz matrix in `O(n^2)` operations.
 """
 function trench(T::SymmetricToeplitz)
-    n = checksquare(T)
+    n = length(T.vc)
     B = zeros(eltype(T), n, n)
     trench!(B, T)
 end
@@ -71,7 +72,7 @@ end
 # uses B to store the inverse
 # NOTE: only populates entries on upper triangle since the inverse is symmetric
 function trench!(B::AbstractMatrix, r::AbstractVector)
-    n = checksquare(B)
+    n = LinearAlgebra.checksquare(B)
     n == length(r) + 1 || throw(DimensionMismatch())
     y = durbin(r)
     γ = inv(1 + dot(r, y))
@@ -87,18 +88,19 @@ function trench!(B::AbstractMatrix, r::AbstractVector)
 end
 
 """
-```
+
     levinson(r::AbstractVector, b::AbstractVector)
-```
-solves `x = T \\ b where T = SymmetricToeplitz(vcat(1, r)), i.e. T_{ij} = r[abs(i-j)]`` where by assumption `r[0] = 1` and `T` is positive definite.
+
+solves `x = T \\ b` where `T = SymmetricToeplitz(vcat(1, r))`, i.e. `T_{ij} = r[abs(i-j)]`
+where by assumption `r[0] = 1` and `T` is positive definite.
 """
 levinson(r::AbstractVector, b::AbstractVector) = levinson!(zero(b), r, b)
 
 """
-```
+
     levinson!(x::AbstractVector, r::AbstractVector, b::AbstractVector, y::AbstractVector = zero(x))
-```
-same as `levinson`, but uses the pre-allocated vector `x` to store the result.
+
+Same as `levinson`, but uses the pre-allocated vector `x` to store the result.
 """
 function levinson!(x::AbstractVector, r::AbstractVector, b::AbstractVector,
                    y::AbstractVector = zero(x))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ using Pkg
 end
 
 using ToeplitzMatrices, StatsBase, Test, LinearAlgebra
-
+using Test: @inferred
 using Base: copyto!
 using FFTW: fft
 
@@ -120,6 +120,7 @@ end
         y = durbin(r)
         b = - (TM \ r)
         @test b ≈ y
+        @inferred durbin(r)
 
         # 2. test trench algorithm for inversion
         B = trench(r[1:end-1])
@@ -127,6 +128,7 @@ end
         @test B ≈ invTM
         @test trench(T) ≈ invTM
         @test trench(TS) ≈ inv(TSM)
+        @inferred trench(TS)
 
         # 3. test levinson algorithm for solves
         b = randn(n)
@@ -136,6 +138,7 @@ end
         @test Tb ≈ y
         @test Tb ≈ levinson(T, b)
         @test TSM \ b ≈ levinson(TS, b)
+        @inferred levinson(TS, b)
     end
 end
 


### PR DESCRIPTION
# Overview 
This PR adds implementations of the Durbin and Levinson algorithms that improve on the performance of StatsBase's implementations by a factor of two for larger matrices. The performance advantage starts to appear before `n = 32` and grow with `n`. Experiments were run on a 2021 MacBook Pro with an M1 Pro.

Since this package specializes on Toeplitz matrices, I think the implementations are better incorporated here than at StatsBase. Further, this PR also adds Trench's algorithm for the efficient inversion of symmetric positive definite Toeplitz matrices. See below for performance benchmarks.

For a reference, see [Golub and Van Loan, page 208.](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwititz36pf1AhXckIkEHWYPAiQQFnoECAUQAQ&url=http%3A%2F%2Fmath.ecnu.edu.cn%2F~jypan%2FTeaching%2Fbooks%2F2013%2520Matrix%2520Computations%25204th.pdf&usg=AOvVaw26GX7osGTu7etg5RSyfh-P)

# Benchmarks

## Durbin
### `n = 4096`
```
durbin
  5.571 ms (2 allocations: 32.05 KiB)
durbin!
  5.568 ms (0 allocations: 0 bytes)
StatsBase.durbin
  11.043 ms (2 allocations: 32.05 KiB)
StatsBase.durbin!
  11.041 ms (0 allocations: 0 bytes)
canonical solve
  161.529 ms (8 allocations: 128.09 MiB)
```

### `n = 32`
```
durbin
  716.241 ns (1 allocation: 336 bytes)
durbin!
  646.341 ns (0 allocations: 0 bytes)
StatsBase.durbin
  818.494 ns (1 allocation: 336 bytes)
StatsBase.durbin!
  794.708 ns (0 allocations: 0 bytes)
canonical solve
  54.375 μs (4 allocations: 9.11 KiB)
```

## Levinson
### `n = 4096`
```
levinson
  9.533 ms (4 allocations: 64.09 KiB)
levinson!
  9.531 ms (2 allocations: 32.05 KiB)
StatsBase.levinson
  23.107 ms (4 allocations: 64.09 KiB)
StatsBase.levinson!
  23.110 ms (0 allocations: 0 bytes)
canonical solve
  161.600 ms (6 allocations: 128.06 MiB)
```

### `n = 32`
```
levinson
  905.273 ns (2 allocations: 672 bytes)
levinson!
  897.925 ns (1 allocation: 336 bytes)
StatsBase.levinson
  1.221 μs (2 allocations: 672 bytes)
StatsBase.levinson!
  1.175 μs (0 allocations: 0 bytes)
direct solve
  52.750 μs (3 allocations: 8.78 KiB)
```

## Trench 
### `n = 4096`
```
trench
  18.469 ms (14 allocations: 128.06 MiB)
canonical inv
  499.677 ms (6 allocations: 130.03 MiB)
```
### `n = 32`
```
trench
  1.279 μs (7 allocations: 8.94 KiB)
canonical inv
  59.542 μs (4 allocations: 24.58 KiB)
```