### PR TITLE
`eigen` for `Circulant`

### DIFF
--- a/src/ToeplitzMatrices.jl
+++ b/src/ToeplitzMatrices.jl
@@ -5,7 +5,8 @@ import DSP: conv
 import Base: adjoint, convert, transpose, size, getindex, similar, copy, getproperty, inv, sqrt, copyto!, reverse, conj, zero, fill!, checkbounds, real, imag, isfinite, DimsInteger, iszero
 import Base: ==, +, -, *, \
 import LinearAlgebra: Cholesky, Factorization
-import LinearAlgebra: ldiv!, factorize, lmul!, pinv, eigvals, cholesky!, cholesky, tril!, triu!, checksquare, rmul!, dot, mul!, tril, triu
+import LinearAlgebra: ldiv!, factorize, lmul!, pinv, eigvals, eigvecs, eigen, Eigen, det
+import LinearAlgebra: cholesky!, cholesky, tril!, triu!, checksquare, rmul!, dot, mul!, tril, triu
 import LinearAlgebra: UpperTriangular, LowerTriangular, Symmetric, Adjoint
 import AbstractFFTs: Plan, plan_fft!
 import StatsBase

--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -317,7 +317,7 @@ function eigvecs(C::Circulant)
     invnorm = 1/√n
     for CI in CartesianIndices(M)
         k, j = Tuple(CI)
-        M[CI] = cispi((k-1) * (j-1) * x) * invnorm
+        M[CI] = _cispi((k-1) * (j-1) * x) * invnorm
     end
     return M
 end

--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -122,7 +122,7 @@ end
 function factorize(A::Toeplitz)
     T = eltype(A)
     m, n = size(A)
-    S = promote_type(T, Complex{Float32})
+    S = promote_type(float(T), Complex{Float32})
     tmp = Vector{S}(undef, m + n - 1)
     copyto!(tmp, A.vc)
     copyto!(tmp, m + 1, Iterators.reverse(A.vr), 1, n - 1)
@@ -142,7 +142,7 @@ StatsBase.levinson(A::AbstractToeplitz, B::AbstractVecOrMat) = StatsBase.levinso
 function factorize(A::SymmetricToeplitz{T}) where {T<:Number}
     vc = A.vc
     m = length(vc)
-    S = promote_type(T, Complex{Float32})
+    S = promote_type(float(T), Complex{Float32})
     tmp = Vector{S}(undef, 2 * m)
     copyto!(tmp, vc)
     @inbounds tmp[m + 1] = zero(T)
@@ -199,7 +199,7 @@ const CirculantFactorization{T, V<:AbstractVector{T}} = ToeplitzFactorization{T,
 function factorize(C::Circulant)
     T = eltype(C)
     vc = C.vc
-    S = promote_type(T, Complex{Float32})
+    S = promote_type(float(T), Complex{Float32})
     tmp = Vector{S}(undef, length(vc))
     copyto!(tmp, vc)
     dft = plan_fft!(tmp)
@@ -302,6 +302,23 @@ end
 
 eigvals(C::Circulant) = eigvals(factorize(C))
 eigvals(C::CirculantFactorization) = copy(C.vcvr_dft)
+_det(C) = prod(eigvals(C))
+det(C::Circulant) = _det(C)
+det(C::Circulant{<:Real}) = real(_det(C))
+function eigvecs(C::Circulant)
+    n = size(C,1)
+    M = Array{complex(float(eltype(C)))}(undef, size(C))
+    x = 2/n
+    invnorm = 1/√n
+    for CI in CartesianIndices(M)
+        k, j = Tuple(CI)
+        M[CI] = cispi((k-1) * (j-1) * x) * invnorm
+    end
+    return M
+end
+function eigen(C::Circulant)
+    Eigen(eigvals(C), eigvecs(C))
+end
 
 sqrt(C::Circulant) = sqrt(factorize(C))
 function sqrt(C::CirculantFactorization)
@@ -394,7 +411,7 @@ function factorize(A::LowerTriangularToeplitz)
     T = eltype(A)
     v = A.v
     n = length(v)
-    S = promote_type(T, Complex{Float32})
+    S = promote_type(float(T), Complex{Float32})
     tmp = zeros(S, 2 * n - 1)
     copyto!(tmp, v)
     dft = plan_fft!(tmp)
@@ -404,7 +421,7 @@ function factorize(A::UpperTriangularToeplitz)
     T = eltype(A)
     v = A.v
     n = length(v)
-    S = promote_type(T, Complex{Float32})
+    S = promote_type(float(T), Complex{Float32})
     tmp = zeros(S, 2 * n - 1)
     tmp[1] = v[1]
     copyto!(tmp, n + 1, Iterators.reverse(v), 1, n - 1)

--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -305,6 +305,11 @@ eigvals(C::CirculantFactorization) = copy(C.vcvr_dft)
 _det(C) = prod(eigvals(C))
 det(C::Circulant) = _det(C)
 det(C::Circulant{<:Real}) = real(_det(C))
+@static if VERSION <= v"1.6"
+    _cispi(x) = cis(pi*x)
+else
+    _cispi(x) = cispi(x)
+end
 function eigvecs(C::Circulant)
     n = size(C,1)
     M = Array{complex(float(eltype(C)))}(undef, size(C))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -462,6 +462,12 @@ end
     for v1i in v1
         @test minimum(abs.(v1i .- v2)) < sqrt(eps(Float64))
     end
+    for (C,M) in ((C1,M1), (C3,M3), (C5,M5))
+        λ, V = eigen(C)
+        @test C * V ≈ V * Diagonal(λ)
+        @test V'V ≈ LinearAlgebra.I
+        @test det(C) ≈ det(M)
+    end
 
     # Test for issue #47
     I = inv(C1)*C1


### PR DESCRIPTION
This complements `eigvals`. After this,
```julia
julia> C = Circulant([1,2,0,0])
4×4 Circulant{Int64, Vector{Int64}}:
 1  0  0  2
 2  1  0  0
 0  2  1  0
 0  0  2  1

julia> eigen(C)
Eigen{ComplexF64, ComplexF64, Matrix{ComplexF64}, Vector{ComplexF64}}
values:
4-element Vector{ComplexF64}:
  3.0 + 0.0im
  1.0 - 2.0im
 -1.0 + 0.0im
  1.0 + 2.0im
vectors:
4×4 Matrix{ComplexF64}:
 0.5+0.0im   0.5+0.0im   0.5+0.0im   0.5+0.0im
 0.5+0.0im   0.0+0.5im  -0.5+0.0im   0.0-0.5im
 0.5+0.0im  -0.5+0.0im   0.5+0.0im  -0.5+0.0im
 0.5+0.0im   0.0-0.5im  -0.5+0.0im   0.0+0.5im
```
The eigenvectors may be computed in `O(n^2)`