### PR TITLE
extend `AbstractMatrix` instead of `similar`

### DIFF
--- a/src/ToeplitzMatrices.jl
+++ b/src/ToeplitzMatrices.jl
@@ -4,6 +4,7 @@ import DSP: conv
 
 import Base: adjoint, convert, transpose, size, getindex, similar, copy, getproperty, inv, sqrt, copyto!, reverse, conj, zero, fill!, checkbounds, real, imag, isfinite, DimsInteger, iszero
 import Base: ==, +, -, *, \
+import Base: AbstractMatrix
 import LinearAlgebra: Cholesky, Factorization
 import LinearAlgebra: ldiv!, factorize, lmul!, pinv, eigvals, eigvecs, eigen, Eigen, det
 import LinearAlgebra: cholesky!, cholesky, tril!, triu!, checksquare, rmul!, dot, mul!, tril, triu

--- a/src/hankel.jl
+++ b/src/hankel.jl
@@ -68,7 +68,7 @@ Base.@propagate_inbounds function getindex(A::Hankel, i::Integer, j::Integer)
     @boundscheck checkbounds(A, i, j)
     return A.v[i+j-1]
 end
-AbstractMatrix{T}(A::Hankel) where {T} = Hankel{T}(AbstractVector{T}(A.v), dims)
+AbstractMatrix{T}(A::Hankel) where {T} = Hankel{T}(AbstractVector{T}(A.v), A.size)
 for fun in (:zero, :conj, :copy, :-, :similar, :real, :imag)
     @eval $fun(A::Hankel) = Hankel($fun(A.v), size(A))
 end

--- a/src/hankel.jl
+++ b/src/hankel.jl
@@ -68,8 +68,7 @@ Base.@propagate_inbounds function getindex(A::Hankel, i::Integer, j::Integer)
     @boundscheck checkbounds(A, i, j)
     return A.v[i+j-1]
 end
-similar(A::Hankel, T::Type, dims::DimsInteger{2}) = Hankel{T}(similar(A.v, T, dims[1]+dims[2]-true), dims)
-similar(A::Hankel, T::Type, dims::Tuple{Int64,Int64}) = Hankel{T}(similar(A.v, T, dims[1]+dims[2]-true), dims) # for ambiguity with `similar(a::AbstractArray, ::Type{T}, dims::Tuple{Vararg{Int64, N}}) where {T, N}` in Base
+AbstractMatrix{T}(A::Hankel) where {T} = Hankel{T}(AbstractVector{T}(A.v), dims)
 for fun in (:zero, :conj, :copy, :-, :similar, :real, :imag)
     @eval $fun(A::Hankel) = Hankel($fun(A.v), size(A))
 end

--- a/src/special.jl
+++ b/src/special.jl
@@ -30,7 +30,7 @@ for TYPE in (:SymmetricToeplitz, :Circulant, :LowerTriangularToeplitz, :UpperTri
             copyto!(A.v,B.v)
             A
         end
-        AbstractMatrix{T}(A::$TYPE) where {T} = $TYPE{T}(convert(AbstractVector{T}, A.v))
+        AbstractMatrix{T}(A::$TYPE) where {T} = $TYPE{T}(AbstractVector{T}(A.v))
         function lmul!(x::Number, A::$TYPE)
             lmul!(x,A.v)
             A

--- a/src/special.jl
+++ b/src/special.jl
@@ -30,7 +30,7 @@ for TYPE in (:SymmetricToeplitz, :Circulant, :LowerTriangularToeplitz, :UpperTri
             copyto!(A.v,B.v)
             A
         end
-        similar(A::$TYPE, T::Type) = $TYPE{T}(similar(A.v, T))
+        AbstractMatrix{T}(A::$TYPE) where {T} = $TYPE{T}(convert(AbstractVector{T}, A.v))
         function lmul!(x::Number, A::$TYPE)
             lmul!(x,A.v)
             A

--- a/src/toeplitz.jl
+++ b/src/toeplitz.jl
@@ -104,10 +104,9 @@ end
 
 adjoint(A::AbstractToeplitz) = transpose(conj(A))
 transpose(A::AbstractToeplitz) = Toeplitz(A.vr, A.vc)
-function similar(A::AbstractToeplitz, T::Type, dims::Dims{2})
-    vc=similar(A.vc, T, dims[1])
-    vr=similar(A.vr, T, dims[2])
-    vr[1]=vc[1]
+function AbstractMatrix{T}(A::AbstractToeplitz) where {T}
+    vc = convert(AbstractVector{T}, _vc(A))
+    vr = convert(AbstractVector{T}, _vr(A))
     Toeplitz{T}(vc,vr)
 end
 for fun in (:zero, :conj, :copy, :-, :real, :imag)

--- a/src/toeplitz.jl
+++ b/src/toeplitz.jl
@@ -105,8 +105,8 @@ end
 adjoint(A::AbstractToeplitz) = transpose(conj(A))
 transpose(A::AbstractToeplitz) = Toeplitz(A.vr, A.vc)
 function AbstractMatrix{T}(A::AbstractToeplitz) where {T}
-    vc = convert(AbstractVector{T}, _vc(A))
-    vr = convert(AbstractVector{T}, _vr(A))
+    vc = AbstractVector{T}(_vc(A))
+    vr = AbstractVector{T}(_vr(A))
     Toeplitz{T}(vc,vr)
 end
 for fun in (:zero, :conj, :copy, :-, :real, :imag)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,8 +74,10 @@ end
 @testset "vector indexing" begin
     T = Toeplitz(rand(3,3))
     @test T[1:2, 1:2] == Matrix(T)[1:2, 1:2]
+    @test AbstractMatrix{ComplexF64}(T) == Toeplitz{ComplexF64}(T.vc, T.vr)
     C = Circulant(1:4)
     @test C[1:2, 1:2] == Matrix(C)[1:2, 1:2]
+    @test AbstractMatrix{ComplexF64}(C) == Circulant{ComplexF64}(C.vc)
 end
 
 @testset "Mixed types" begin
@@ -176,6 +178,9 @@ end
         @test diag(H) == [1,3,5,7,9]
 
         @test H[1:2, 1:2] == Matrix(H)[1:2, 1:2]
+        Hc = AbstractMatrix{ComplexF64}(H)
+        @test Hc isa Hankel{ComplexF64}
+        @test size(Hc) == size(H)
 
         @test copy(H) == copyto!(similar(H), H)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -475,6 +475,9 @@ end
     e = rand(5)
     # I should be close to identity
     @test I*e ≈ I2*e ≈ e
+
+    D = Diagonal(axes(C1,2))
+    @test mul!(similar(C1), C1, D) ≈ C1 * D
 end
 
 @testset "TriangularToeplitz" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,13 @@ for (As, Al, st) in cases
     end
 end
 
+@testset "vector indexing" begin
+    T = Toeplitz(rand(3,3))
+    @test T[1:2, 1:2] == Matrix(T)[1:2, 1:2]
+    C = Circulant(1:4)
+    @test C[1:2, 1:2] == Matrix(C)[1:2, 1:2]
+end
+
 @testset "Mixed types" begin
     @test eltype(Toeplitz([1, 2], [1, 2])) === Int
     @test Toeplitz([1, 2], [1, 2]) * ones(2) == fill(3, 2)
@@ -167,6 +174,8 @@ end
         @test H[2,2] == 3
         @test H[7]  == 3
         @test diag(H) == [1,3,5,7,9]
+
+        @test H[1:2, 1:2] == Matrix(H)[1:2, 1:2]
 
         @test copy(H) == copyto!(similar(H), H)
 


### PR DESCRIPTION
This makes the following work:
```julia
julia> C = Circulant([1,2,0,0])
4×4 Circulant{Int64, Vector{Int64}}:
 1  0  0  2
 2  1  0  0
 0  2  1  0
 0  0  2  1

julia> D = Diagonal(axes(C,2))
4×4 Diagonal{Int64, Base.OneTo{Int64}}:
 1  ⋅  ⋅  ⋅
 ⋅  2  ⋅  ⋅
 ⋅  ⋅  3  ⋅
 ⋅  ⋅  ⋅  4

julia> C * D
4×4 Matrix{Int64}:
 1  0  0  8
 2  2  0  0
 0  4  3  0
 0  0  6  4

julia> C = Circulant([1,2,0,2])
4×4 Circulant{Int64, Vector{Int64}}:
 1  2  0  2
 2  1  2  0
 0  2  1  2
 2  0  2  1

julia> sort(eigvals(C), by=reim) ≈ eigvals(Symmetric(C))
true
```
`similar` should return a mutable collection that has `setindex!` defined.