### PR TITLE
Abstract type for matrices wrapping a single vector

### DIFF
--- a/src/ToeplitzMatrices.jl
+++ b/src/ToeplitzMatrices.jl
@@ -3,6 +3,7 @@ module ToeplitzMatrices
 import DSP: conv
 
 import Base: adjoint, convert, transpose, size, getindex, similar, copy, getproperty, inv, sqrt, copyto!, reverse, conj, zero, fill!, checkbounds, real, imag, isfinite, DimsInteger, iszero
+import Base: parent
 import Base: ==, +, -, *, \
 import Base: AbstractMatrix
 import LinearAlgebra: Cholesky, Factorization

--- a/src/special.jl
+++ b/src/special.jl
@@ -1,50 +1,58 @@
 # special Toeplitz types that can be represented by a single vector
 # Symmetric, Circulant, LowerTriangular, UpperTriangular
+
+abstract type AbstractToeplitzSingleVector{T} <: AbstractToeplitz{T} end
+
+function size(A::AbstractToeplitzSingleVector)
+    n = length(A.v)
+    (n,n)
+end
+
+adjoint(A::AbstractToeplitzSingleVector) = transpose(conj(A))
+function zero!(A::AbstractToeplitzSingleVector)
+    fill!(A.v, zero(eltype(A)))
+    return A
+end
+
+function lmul!(x::Number, A::AbstractToeplitzSingleVector)
+    lmul!(x,A.v)
+    A
+end
+function rmul!(A::AbstractToeplitzSingleVector, x::Number)
+    rmul!(A.v,x)
+    A
+end
+
+for fun in (:iszero,)
+    @eval $fun(A::AbstractToeplitzSingleVector) = $fun(A.v)
+end
+
 for TYPE in (:SymmetricToeplitz, :Circulant, :LowerTriangularToeplitz, :UpperTriangularToeplitz)
     @eval begin
-        struct $TYPE{T, V<:AbstractVector{T}} <: AbstractToeplitz{T}
+        struct $TYPE{T, V<:AbstractVector{T}} <: AbstractToeplitzSingleVector{T}
             v::V
         end
-        $TYPE{T}(v::V) where {T,V<:AbstractVector{T}} = $TYPE{T,V}(v)
-        $TYPE{T}(v::AbstractVector) where T = $TYPE{T}(convert(AbstractVector{T},v))
+        function $TYPE{T}(v::AbstractVector) where T
+            vT = convert(AbstractVector{T},v)
+            $TYPE{T, typeof(vT)}(vT)
+        end
 
         AbstractToeplitz{T}(A::$TYPE) where T = $TYPE{T}(A)
         $TYPE{T}(A::$TYPE) where T = $TYPE{T}(convert(AbstractVector{T},A.v))
         convert(::Type{$TYPE{T}}, A::$TYPE) where {T} = $TYPE{T}(A)
 
-        size(A::$TYPE) = (length(A.v),length(A.v))
-
-        adjoint(A::$TYPE) = transpose(conj(A))
         (*)(scalar::Number, C::$TYPE) = $TYPE(scalar * C.v)
         (*)(C::$TYPE, scalar::Number) = $TYPE(C.v * scalar)
         (==)(A::$TYPE,B::$TYPE) = A.v==B.v
-        function zero!(A::$TYPE)
-            if isconcrete(A)
-                fill!(A.v,zero(eltype(A)))
-            else
-                A.v=zero(A.v)
-            end
-        end
 
         function copyto!(A::$TYPE,B::$TYPE)
             copyto!(A.v,B.v)
             A
         end
         AbstractMatrix{T}(A::$TYPE) where {T} = $TYPE{T}(AbstractVector{T}(A.v))
-        function lmul!(x::Number, A::$TYPE)
-            lmul!(x,A.v)
-            A
-        end
-        function rmul!(A::$TYPE, x::Number)
-            rmul!(A.v,x)
-            A
-        end
     end
     for fun in (:zero, :conj, :copy, :-, :real, :imag)
         @eval $fun(A::$TYPE) = $TYPE($fun(A.v))
-    end
-    for fun in (:iszero,)
-        @eval $fun(A::$TYPE) = $fun(A.v)
     end
     for op in (:+, :-)
         @eval $op(A::$TYPE,B::$TYPE) = $TYPE($op(A.v,B.v))

--- a/src/special.jl
+++ b/src/special.jl
@@ -40,8 +40,7 @@ for TYPE in (:SymmetricToeplitz, :Circulant, :LowerTriangularToeplitz, :UpperTri
         end
 
         AbstractToeplitz{T}(A::$TYPE) where T = $TYPE{T}(A)
-        $TYPE{T}(A::$TYPE) where T = $TYPE{T}(convert(AbstractVector{T},A.v))
-        convert(::Type{$TYPE{T}}, A::$TYPE) where {T} = $TYPE{T}(A)
+        convert(::Type{$TYPE{T}}, A::$TYPE) where {T} = A isa $TYPE{T} ? A : $TYPE{T}(A)::$TYPE{T}
 
         (*)(scalar::Number, C::$TYPE) = $TYPE(scalar * C.v)
         (*)(C::$TYPE, scalar::Number) = $TYPE(C.v * scalar)

--- a/src/special.jl
+++ b/src/special.jl
@@ -3,28 +3,30 @@
 
 abstract type AbstractToeplitzSingleVector{T} <: AbstractToeplitz{T} end
 
+parent(A::AbstractToeplitzSingleVector) = A.v
+
 function size(A::AbstractToeplitzSingleVector)
-    n = length(A.v)
+    n = length(parent(A))
     (n,n)
 end
 
 adjoint(A::AbstractToeplitzSingleVector) = transpose(conj(A))
 function zero!(A::AbstractToeplitzSingleVector)
-    fill!(A.v, zero(eltype(A)))
+    fill!(parent(A), zero(eltype(A)))
     return A
 end
 
 function lmul!(x::Number, A::AbstractToeplitzSingleVector)
-    lmul!(x,A.v)
+    lmul!(x,parent(A))
     A
 end
 function rmul!(A::AbstractToeplitzSingleVector, x::Number)
-    rmul!(A.v,x)
+    rmul!(parent(A),x)
     A
 end
 
 for fun in (:iszero,)
-    @eval $fun(A::AbstractToeplitzSingleVector) = $fun(A.v)
+    @eval $fun(A::AbstractToeplitzSingleVector) = $fun(parent(A))
 end
 
 for TYPE in (:SymmetricToeplitz, :Circulant, :LowerTriangularToeplitz, :UpperTriangularToeplitz)


### PR DESCRIPTION
Defining this abstract type would mean that several functions need to only be extended for the abstract type instead of for every concrete subtype. Also, future types subtyping the abstract type get these methods for free.