### PR TITLE
Non-allocating _circulate

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.8.1"
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
@@ -13,6 +14,7 @@ AbstractFFTs = "0.4, 0.5, 1"
 Aqua = "0.6"
 DSP = "0.7.7"
 FFTW = "1"
+FillArrays = "1"
 StatsBase = "0.32, 0.33, 0.34"
 julia = "1.0"
 

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.8.1"
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
-FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
@@ -14,7 +13,7 @@ AbstractFFTs = "0.4, 0.5, 1"
 Aqua = "0.6"
 DSP = "0.7.7"
 FFTW = "1"
-FillArrays = "1"
+FillArrays = "0.12, 0.13, 1"
 StatsBase = "0.32, 0.33, 0.34"
 julia = "1.0"
 

--- a/src/ToeplitzMatrices.jl
+++ b/src/ToeplitzMatrices.jl
@@ -14,8 +14,6 @@ import LinearAlgebra: UpperTriangular, LowerTriangular, Symmetric, Adjoint
 import AbstractFFTs: Plan, plan_fft!
 import StatsBase
 
-using FillArrays
-
 export AbstractToeplitz, Toeplitz, SymmetricToeplitz, Circulant, LowerTriangularToeplitz, UpperTriangularToeplitz, TriangularToeplitz, Hankel
 export durbin, trench, levinson
 

--- a/src/ToeplitzMatrices.jl
+++ b/src/ToeplitzMatrices.jl
@@ -14,6 +14,8 @@ import LinearAlgebra: UpperTriangular, LowerTriangular, Symmetric, Adjoint
 import AbstractFFTs: Plan, plan_fft!
 import StatsBase
 
+using FillArrays
+
 export AbstractToeplitz, Toeplitz, SymmetricToeplitz, Circulant, LowerTriangularToeplitz, UpperTriangularToeplitz, TriangularToeplitz, Hankel
 export durbin, trench, levinson
 

--- a/src/special.jl
+++ b/src/special.jl
@@ -116,11 +116,9 @@ function getproperty(A::UpperTriangularToeplitz, s::Symbol)
     end
 end
 
-_circulate(v::AbstractVector) = reverse(v, 2)
+_circulate(v::AbstractVector) = view(Circulant(v), 1, :)
 function _firstnonzero(v::AbstractVector)
-    w = zero(v)
-    w[1] = v[1]
-    w
+    OneElement(v[1], 1, length(v))
 end
 
 # transpose

--- a/src/special.jl
+++ b/src/special.jl
@@ -118,7 +118,9 @@ end
 
 _circulate(v::AbstractVector) = view(Circulant(v), 1, :)
 function _firstnonzero(v::AbstractVector)
-    OneElement(v[1], 1, length(v))
+    w = zero(v)
+    w[1] = v[1]
+    w
 end
 
 # transpose


### PR DESCRIPTION
As discussed in https://github.com/JuliaLinearAlgebra/ToeplitzMatrices.jl/pull/95#issuecomment-1570256157

```julia
julia> @btime Circulant{Int}(1:4, :U)
  1.684 ns (0 allocations: 0 bytes)
4×4 Circulant{Int64, SubArray{Int64, 1, Circulant{Int64, UnitRange{Int64}}, Tuple{Int64, Base.Slice{Base.OneTo{Int64}}}, false}}:
 1  2  3  4
 4  1  2  3
 3  4  1  2
 2  3  4  1
```
cc @putianyi889 