### PR TITLE
Faster eigvecs for SymTridiagonal toeplitz

### DIFF
--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -44,6 +44,10 @@ function _eigvals_toeplitz(T)
     return vals
 end
 
+_eigvec_eltype(A::Union{SymTridiagonal,
+                    Symmetric{<:Any,<:Tridiagonal}}) = float(eltype(A))
+_eigvec_eltype(A) = complex(float(eltype(A)))
+
 _eigvec_prefactor(A, cm1, c1, m) = sqrt(complex(cm1/c1))^m
 _eigvec_prefactor(A::Union{SymTridiagonal, Symmetric{<:Any, <:Tridiagonal}}, cm1, c1, m) = oneunit(_eigvec_eltype(A))
 
@@ -53,9 +57,6 @@ function _eigvec_prefactors(A, cm1, c1)
 end
 _eigvec_prefactors(A::Union{SymTridiagonal, Symmetric{<:Any, <:Tridiagonal}}, cm1, c1) =
     Fill(_eigvec_prefactor(A, cm1, c1, 1), size(A,1))
-
-_eigvec_eltype(A::SymTridiagonal) = float(eltype(A))
-_eigvec_eltype(A) = complex(float(eltype(A)))
 
 @static if !isdefined(Base, :eachcol)
     eachcol(A) = (view(A,:,i) for i in axes(A,2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -584,7 +584,7 @@ end
 @testset "eigen" begin
     sortby = x -> (real(x), imag(x))
     @testset "Tridiagonal Toeplitz" begin
-        _sizes = (1, 2, 6, 10)
+        _sizes = (1, 2, 5, 6, 10, 15)
         sizes = VERSION >= v"1.6" ? (0, _sizes...) : _sizes
         @testset for n in sizes
             @testset "Tridiagonal" begin


### PR DESCRIPTION
Reducing the number of `sinpi` calls leads to a speed-up.

On master
```julia
julia> S = SymTridiagonal(Fill(1, 2000), Fill(2,1999));

julia> @btime eigvecs($S);
  51.729 ms (2 allocations: 30.52 MiB)
```
This PR
```julia
julia> @btime eigvecs($S);
  23.320 ms (2 allocations: 30.52 MiB)
```