### PR TITLE
Disable some eigen methods

### DIFF
--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -16,7 +16,7 @@ for MT in (:(SymTridiagonal{<:Union{Real,Complex}, <:AbstractFillVector}),
         if n <= 2 # repeated roots possible
             eigvals(Matrix(A))
         else
-            _eigvals_toeplitz(A)
+            _eigvals(A)
         end
     end
 end
@@ -32,17 +32,17 @@ for MT in (:(SymTridiagonal{<:Union{Real,Complex}, <:AbstractFillVector}),
 end
 
 
-___eigvals_toeplitz(a, sqrtbc, n) = [a + 2 * sqrtbc * cospi(q/(n+1)) for q in n:-1:1]
+___eigvals(a, sqrtbc, n) = [a + 2 * sqrtbc * cospi(q/(n+1)) for q in n:-1:1]
 
-__eigvals_toeplitz(::AbstractMatrix, a, b, c, n) =
-    ___eigvals_toeplitz(a, √(b*c), n)
-__eigvals_toeplitz(::Union{SymTridiagonal, Symmetric{<:Any, <:Tridiagonal}}, a, b, c, n) =
-    ___eigvals_toeplitz(a, b, n)
-__eigvals_toeplitz(::Hermitian{<:Any, <:Tridiagonal}, a, b, c, n) =
-    ___eigvals_toeplitz(real(a), abs(b), n)
+__eigvals(::AbstractMatrix, a, b, c, n) =
+    ___eigvals(a, √(complex(b*c)), n)
+__eigvals(::Union{SymTridiagonal, Symmetric{<:Any, <:Tridiagonal}}, a, b, c, n) =
+    ___eigvals(a, b, n)
+__eigvals(::Hermitian{<:Any, <:Tridiagonal}, a, b, c, n) =
+    ___eigvals(real(a), abs(b), n)
 
 # triangular Toeplitz
-function _eigvals_toeplitz(T)
+function _eigvals(T)
     require_one_based_indexing(T)
     n = checksquare(T)
     # extra care to handle 0x0 and 1x1 matrices
@@ -52,7 +52,7 @@ function _eigvals_toeplitz(T)
     b = get(T, (2,1), zero(eltype(T)))
     # superdiagonal
     c = get(T, (1,2), zero(eltype(T)))
-    vals = __eigvals_toeplitz(T, a, b, c, n)
+    vals = __eigvals(T, a, b, c, n)
     return vals
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -587,11 +587,19 @@ end
         @testset for n in sizes
             if VERSION >= v"1.9"
                 @testset "Tridiagonal" begin
+                    evm1r = Fill(2, max(0, n-1))
+                    ev1r = Fill(3, max(0,n-1))
+                    dvr = Fill(-4, n)
+                    evm1c = Fill(2+3im, max(0, n-1))
+                    dvc = Fill(-4+4im, n)
+                    ev1c = Fill(3im, max(0,n-1))
+
                     for (dl, d, du) in (
-                        (Fill(2, max(0, n-1)), Fill(-4, n), Fill(3, max(0,n-1))),
-                        (Fill(2, max(0, n-1)), Fill(-4, n), Fill(-3, max(0,n-1))),
-                        (Fill(2+3im, max(0, n-1)), Fill(-4+4im, n), Fill(3im, max(0,n-1)))
-                        )
+                            (evm1r, dvr, ev1r),
+                            (evm1r, dvr, -ev1r),
+                            (evm1c, dvc, ev1c),
+                            )
+
                         T = Tridiagonal(dl, d, du)
                         λT = eigvals(T)
                         λTM = eigvals(Matrix(T))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -586,18 +586,20 @@ end
     @testset "Tridiagonal Toeplitz" begin
         sizes = (1, 2, 5, 6, 10, 15)
         @testset for n in sizes
-            @testset "Tridiagonal" begin
-                for (dl, d, du) in (
-                    (Fill(2, max(0, n-1)), Fill(-4, n), Fill(3, max(0,n-1))),
-                    (Fill(2, max(0, n-1)), Fill(-4, n), Fill(-3, max(0,n-1))),
-                    (Fill(2+3im, max(0, n-1)), Fill(-4+4im, n), Fill(3im, max(0,n-1)))
-                    )
-                    T = Tridiagonal(dl, d, du)
-                    λT = eigvals(T)
-                    λTM = eigvals(Matrix(T))
-                    @test sort(λT, by=sortby) ≈ sort(λTM, by=sortby)
-                    λ, V = eigen(T)
-                    @test T * V ≈ V * Diagonal(λ)
+            if VERSION >= v"1.9"
+                @testset "Tridiagonal" begin
+                    for (dl, d, du) in (
+                        (Fill(2, max(0, n-1)), Fill(-4, n), Fill(3, max(0,n-1))),
+                        (Fill(2, max(0, n-1)), Fill(-4, n), Fill(-3, max(0,n-1))),
+                        (Fill(2+3im, max(0, n-1)), Fill(-4+4im, n), Fill(3im, max(0,n-1)))
+                        )
+                        T = Tridiagonal(dl, d, du)
+                        λT = eigvals(T)
+                        λTM = eigvals(Matrix(T))
+                        @test sort(λT, by=sortby) ≈ sort(λTM, by=sortby)
+                        λ, V = eigen(T)
+                        @test T * V ≈ V * Diagonal(λ)
+                    end
                 end
             end
 
@@ -628,21 +630,23 @@ end
                 end
             end
 
-            @testset "Hermitian Tridiagonal" begin
-                _dvR = Fill(2, n)
-                _evR = Fill(3, max(0, n-1))
-                _dvc = complex(_dvR)
-                _evc = Fill(3-4im, max(0, n-1))
-                for (dv, ev) in ((_dvc, _evc), (_dvc, conj(_evc)),
-                                    (_dvR, _evR), (_dvR, -_evR))
-                    HT = Hermitian(Tridiagonal(ev, dv, ev))
-                    λHT = eigvals(HT)
-                    λHTM = eigvals(Matrix(HT))
-                    @test sort(λHT, by=sortby) ≈ sort(λHTM, by=sortby)
-                    @test eltype(λHT) <: Real
-                    λ, V = eigen(HT)
-                    @test V'V ≈ I
-                    @test V' * HT * V ≈ Diagonal(λ)
+            if VERSION >= v"1.9"
+                @testset "Hermitian Tridiagonal" begin
+                    _dvR = Fill(2, n)
+                    _evR = Fill(3, max(0, n-1))
+                    _dvc = complex(_dvR)
+                    _evc = Fill(3-4im, max(0, n-1))
+                    for (dv, ev) in ((_dvc, _evc), (_dvc, conj(_evc)),
+                                        (_dvR, _evR), (_dvR, -_evR))
+                        HT = Hermitian(Tridiagonal(ev, dv, ev))
+                        λHT = eigvals(HT)
+                        λHTM = eigvals(Matrix(HT))
+                        @test sort(λHT, by=sortby) ≈ sort(λHTM, by=sortby)
+                        @test eltype(λHT) <: Real
+                        λ, V = eigen(HT)
+                        @test V'V ≈ I
+                        @test V' * HT * V ≈ Diagonal(λ)
+                    end
                 end
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -582,7 +582,6 @@ end
 end
 
 @testset "eigen" begin
-    sortby = x -> (real(x), imag(x))
     @testset "Tridiagonal Toeplitz" begin
         sizes = (1, 2, 5, 6, 10, 15)
         @testset for n in sizes
@@ -596,9 +595,12 @@ end
                         T = Tridiagonal(dl, d, du)
                         λT = eigvals(T)
                         λTM = eigvals(Matrix(T))
-                        @test sort(λT, by=sortby) ≈ sort(λTM, by=sortby)
+                        @test all(x -> any(y -> y ≈ x, λTM), λT)
                         λ, V = eigen(T)
                         @test T * V ≈ V * Diagonal(λ)
+
+                        # Test that internal methods are correct,
+                        # aside from the ordering of eigenvectors
                         λT2 = ToeplitzMatrices._eigvals(T)
                         @test all(x -> any(y -> y ≈ x, λTM), λT2)
                         V2 = ToeplitzMatrices._eigvecs(T)
@@ -615,10 +617,10 @@ end
                 _ev = Fill(3, max(0,n-1))
                 for dv in (_dv, -_dv), ev in (_ev, -_ev)
                     for ST in (SymTridiagonal(dv, ev), Symmetric(Tridiagonal(ev, dv, ev)))
-                        evST = eigvals(ST)
-                        evSTM = eigvals(Matrix(ST))
-                        @test sort(evST, by=sortby) ≈ sort(evSTM, by=sortby)
-                        @test eltype(evST) <: Real
+                        λST = eigvals(ST)
+                        λSTM = eigvals(Matrix(ST))
+                        @test all(x -> any(y -> y ≈ x, λSTM), λST)
+                        @test eltype(λST) <: Real
                         λ, V = eigen(ST)
                         @test V'V ≈ I
                         @test V' * ST * V ≈ Diagonal(λ)
@@ -630,7 +632,7 @@ end
                     for ST2 in (SymTridiagonal(dv, ev), Symmetric(Tridiagonal(ev, dv, ev)))
                         λST = eigvals(ST2)
                         λSTM = eigvals(Matrix(ST2))
-                        @test sort(λST, by=sortby) ≈ sort(λSTM, by=sortby)
+                        @test all(x -> any(y -> y ≈ x, λSTM), λST)
                         λ, V = eigen(ST2)
                         @test ST2 * V ≈ V * Diagonal(λ)
                     end
@@ -648,11 +650,14 @@ end
                         HT = Hermitian(Tridiagonal(ev, dv, ev))
                         λHT = eigvals(HT)
                         λHTM = eigvals(Matrix(HT))
-                        @test sort(λHT, by=sortby) ≈ sort(λHTM, by=sortby)
+                        @test all(x -> any(y -> y ≈ x, λHTM), λHT)
                         @test eltype(λHT) <: Real
                         λ, V = eigen(HT)
                         @test V'V ≈ I
                         @test V' * HT * V ≈ Diagonal(λ)
+
+                        # Test that internal methods are correct,
+                        # aside from the ordering of eigenvectors
                         λHT2 = ToeplitzMatrices._eigvals(HT)
                         @test all(x -> any(y -> y ≈ x, λHTM), λHT2)
                         V2 = ToeplitzMatrices._eigvecs(HT)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -599,6 +599,13 @@ end
                         @test sort(λT, by=sortby) ≈ sort(λTM, by=sortby)
                         λ, V = eigen(T)
                         @test T * V ≈ V * Diagonal(λ)
+                        λT2 = ToeplitzMatrices._eigvals(T)
+                        @test all(x -> any(y -> y ≈ x, λTM), λT2)
+                        V2 = ToeplitzMatrices._eigvecs(T)
+                        for v in eachcol(V2)
+                            w = T * v
+                            @test any(λ -> w ≈ λ * v, λT2)
+                        end
                     end
                 end
             end
@@ -646,6 +653,13 @@ end
                         λ, V = eigen(HT)
                         @test V'V ≈ I
                         @test V' * HT * V ≈ Diagonal(λ)
+                        λHT2 = ToeplitzMatrices._eigvals(HT)
+                        @test all(x -> any(y -> y ≈ x, λHTM), λHT2)
+                        V2 = ToeplitzMatrices._eigvecs(HT)
+                        for v in eachcol(V2)
+                            w = HT * v
+                            @test any(λ -> w ≈ λ * v, λHT2)
+                        end
                     end
                 end
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -611,9 +611,9 @@ end
             end
 
             @testset "SymTridiagonal/Symmetric" begin
-                dv = Fill(1, n)
+                _dv = Fill(1, n)
                 _ev = Fill(3, max(0,n-1))
-                for ev in (_ev, -_ev)
+                for dv in (_dv, -_dv), ev in (_ev, -_ev)
                     for ST in (SymTridiagonal(dv, ev), Symmetric(Tridiagonal(ev, dv, ev)))
                         evST = eigvals(ST)
                         evSTM = eigvals(Matrix(ST))


### PR DESCRIPTION
The eigenvectors and eigenvalues seem to be ordered differently for certain general Tridiagonal and Hermitian matrices, so I'm disabling these methods for now. The specializations may be reintroduced later once the issue is resolved.