### PR TITLE
Don't specialize `similar` for Hankel

### DIFF
--- a/src/hankel.jl
+++ b/src/hankel.jl
@@ -72,7 +72,7 @@ Base.@propagate_inbounds function getindex(A::Hankel, i::Integer, j::Integer)
     return A.v[i+j-1]
 end
 AbstractMatrix{T}(A::Hankel) where {T} = Hankel{T}(AbstractVector{T}(A.v), A.size)
-for fun in (:zero, :conj, :copy, :-, :similar, :real, :imag)
+for fun in (:zero, :conj, :copy, :-, :real, :imag)
     @eval $fun(A::Hankel) = Hankel($fun(A.v), size(A))
 end
 for op in (:+, :-)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -233,6 +233,12 @@ end
         @test_throws ArgumentError Hankel(Int[], (3,4))
         @test_throws ArgumentError Hankel(1:5, (3,4))
     end
+
+    @testset "similar" begin
+        H = Hankel(1:4)
+        M = copyto!(similar(H), H)
+        @test triu(M) == triu(Matrix(H))
+    end
 end
 
 @testset "Convert" begin


### PR DESCRIPTION
Since the output of `similar` should be mutable, and `Hankel` doesn't support `setindex!`, we shouldn't specialize `similar(::Hankel)` to return a `Hankel`. This PR removes the specialization.