### PR TITLE
eigen for triangular

### DIFF
--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -433,3 +433,9 @@ function factorize(A::UpperTriangularToeplitz)
     dft = plan_fft!(tmp)
     return ToeplitzFactorization{T,typeof(A),S,typeof(dft)}(dft * tmp, similar(tmp), dft)
 end
+
+# triangular
+eigvals(T::TriangularToeplitz) = diag(T)
+eigvecs(U::UpperTriangularToeplitz) = eigvecs(UpperTriangular(Matrix(U)))
+eigvecs(L::LowerTriangularToeplitz) = eigvecs(LowerTriangular(Matrix(L)))
+eigen(U::TriangularToeplitz) = Eigen(eigvals(U), eigvecs(U))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -634,6 +634,16 @@ end
         @test_broken inv(TU)::TriangularToeplitz ≈ inv(Matrix(TU))
         @test inv(TL)::TriangularToeplitz ≈ inv(Matrix(TL))
     end
+
+    @testset "eigen" begin
+        for T in (UpperTriangularToeplitz, LowerTriangularToeplitz)
+            for p in ([1:6;], rand(ComplexF64, 5))
+                M = T(p)
+                λ, V = eigen(M)
+                @test M * V ≈ V * Diagonal(λ)
+            end
+        end
+    end
 end
 
 @testset "Cholesky" begin


### PR DESCRIPTION
This uses the triangular structure in the eigenvalue decomposition.

On master,
```julia
julia> U = UpperTriangularToeplitz(rand(1000));

julia> @btime eigvals($U);
  9.915 ms (13 allocations: 7.92 MiB)

julia> @btime eigen($U);
  90.046 ms (15 allocations: 16.29 MiB)
```
This PR
```julia
julia> @btime eigvals($U);
  12.535 ns (0 allocations: 0 bytes)

julia> @btime eigen($U);
  68.200 ms (12 allocations: 30.54 MiB)
```