### PR TITLE
Display triangular matrices with dots

### DIFF
--- a/src/special.jl
+++ b/src/special.jl
@@ -249,3 +249,11 @@ triu(A::TriangularToeplitz, k::Integer=0) = triu!(_copymutable(A), k)
 
 isdiag(A::Union{Circulant, LowerTriangularToeplitz, SymmetricToeplitz}) = all(iszero, @view _vc(A)[2:end])
 isdiag(A::UpperTriangularToeplitz) = all(iszero, @view _vr(A)[2:end])
+
+# display triangular matrices with dots
+function Base.replace_in_print_matrix(A::UpperTriangularToeplitz, i::Integer, j::Integer, s::AbstractString)
+    i <= j ? s : Base.replace_with_centered_mark(s)
+end
+function Base.replace_in_print_matrix(A::LowerTriangularToeplitz, i::Integer, j::Integer, s::AbstractString)
+    i >= j ? s : Base.replace_with_centered_mark(s)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -634,6 +634,20 @@ end
         @test_broken inv(TU)::TriangularToeplitz ≈ inv(Matrix(TU))
         @test inv(TL)::TriangularToeplitz ≈ inv(Matrix(TL))
     end
+
+    @testset "display" begin
+        UT = UpperTriangularToeplitz([1,2,3,4])
+        U = UpperTriangular(Matrix(UT))
+        st = sprint(show, "text/plain", UT)
+        s = sprint(show, "text/plain", U)
+        @test split(st, '\n')[2:end] == split(s, '\n')[2:end]
+
+        LT = LowerTriangularToeplitz([1,2,3,4])
+        L = LowerTriangular(Matrix(LT))
+        st = sprint(show, "text/plain", LT)
+        s = sprint(show, "text/plain", L)
+        @test split(st, '\n')[2:end] == split(s, '\n')[2:end]
+    end
 end
 
 @testset "Cholesky" begin


### PR DESCRIPTION
After this, the structured zeros of a `UpperTriangularToeplitz` are displayed with dots, as in a `UpperTriangular`:
```julia
julia> U = UpperTriangularToeplitz([1,2,3,4])
4×4 UpperTriangularToeplitz{Int64, Vector{Int64}}:
 1  2  3  4
 ⋅  1  2  3
 ⋅  ⋅  1  2
 ⋅  ⋅  ⋅  1
```
This involves extending `Base.replace_in_print_matrix`, which is internal to `Base` (although it should perhaps be public).