### PR TITLE
Limit factorization size method to Circulant

### DIFF
--- a/src/ToeplitzMatrices.jl
+++ b/src/ToeplitzMatrices.jl
@@ -99,8 +99,6 @@ struct ToeplitzFactorization{T,A<:AbstractToeplitz{T},S<:Number,P<:Plan{S}} <: F
     tmp::Vector{S}
     dft::P
 end
-Base.size(T::ToeplitzFactorization) = (s = size(T.dft,1); (s, s))
-Base.size(T::ToeplitzFactorization, i::Integer) = size(T)[i]
 
 include("toeplitz.jl")
 include("special.jl")

--- a/src/special.jl
+++ b/src/special.jl
@@ -257,3 +257,7 @@ end
 function Base.replace_in_print_matrix(A::LowerTriangularToeplitz, i::Integer, j::Integer, s::AbstractString)
     i >= j ? s : Base.replace_with_centered_mark(s)
 end
+
+# size for factorize
+size(T::ToeplitzFactorization{<:Any, <:Circulant}) = (s = size(T.dft,1); (s, s))
+size(T::ToeplitzFactorization{<:Any, <:Circulant}, i::Integer) = size(T)[i]


### PR DESCRIPTION
With this method, a `Circulant` satisfies
```julia
julia> C = Circulant(1:4);

julia> size(C) == size(factorize(C))
true
```
This doesn't hold for other `AbstractToeplitz` types given the current definition, so it's best to limit these for now.