### PR TITLE
Non-allocating adjoint for Hankel

### DIFF
--- a/src/hankel.jl
+++ b/src/hankel.jl
@@ -100,7 +100,9 @@ for fun in (:fill!, :rmul!)
 end
 
 transpose(A::Hankel) = Hankel(A.v, reverse(size(A)))
-adjoint(A::Hankel) = transpose(conj(A))
+adjoint(A::Hankel) = Hankel(vec(adjoint(A.v)), reverse(size(A)))
+issymmetric(A::Hankel) = size(A,1) == size(A,2)
+ishermitian(A::Hankel{<:Number}) = isreal(A) && issymmetric(A)
 (==)(A::Hankel, B::Hankel) = A.v == B.v && size(A) == size(B)
 (*)(scalar::Number, C::Hankel) = Hankel(scalar * C.v, size(C))
 (*)(C::Hankel,scalar::Number) = Hankel(C.v * scalar, size(C))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -255,7 +255,9 @@ end
         @test H2 isa Hankel
         @test H2 == Matrix(H)'
         H = Hankel([(1:4);])
-        @test H' === H
+        H2 = H'
+        H.v[1] = 10
+        @test H2.v[1] == 10
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -239,6 +239,24 @@ end
         M = copyto!(similar(H), H)
         @test triu(M) == triu(Matrix(H))
     end
+
+    @testset "issymmetric/ishermitian" begin
+        H = Hankel(1:4)
+        @test issymmetric(H)
+        @test ishermitian(H)
+        H = Hankel((1:4)*im)
+        @test issymmetric(H)
+        @test !ishermitian(H)
+    end
+
+    @testset "adjoint" begin
+        H = Hankel([(1:4)*im;])
+        H2 = H'
+        @test H2 isa Hankel
+        @test H2 == Matrix(H)'
+        H = Hankel([(1:4);])
+        @test H' === H
+    end
 end
 
 @testset "Convert" begin


### PR DESCRIPTION
Also, specialize `issymmetric`/`ishermitian` to return in `O(1)` time.